### PR TITLE
feat(habits): add create-habit flow and wire up habit service

### DIFF
--- a/ios/SparkApp/SparkApp/API/APIClient.swift
+++ b/ios/SparkApp/SparkApp/API/APIClient.swift
@@ -12,55 +12,42 @@ struct APIClient {
     var session: URLSession = .shared
 
     func send<Response: Decodable>(_ endpoint: Endpoint) async throws -> Response {
-        // Build URL
-        guard var components = URLComponents(
-            url: environment.baseURL, resolvingAgainstBaseURL: false
-        ) else { throw APIError.invalidURL }
-
-        components.path += endpoint.path.hasPrefix("/") ? endpoint.path : "/" + endpoint.path
-        if !endpoint.queryItems.isEmpty { components.queryItems = endpoint.queryItems }
-        guard let url = components.url else { throw APIError.invalidURL }
-
-        // Build request
-        var request = URLRequest(url: url)
-        request.httpMethod = endpoint.method.rawValue
-        request.setValue("true", forHTTPHeaderField: "ngrok-skip-browser-warning")
-
-        for (key, value) in endpoint.headers {
-            request.setValue(value, forHTTPHeaderField: key)
-        }
-
-        if endpoint.body != nil  {
-            request.httpBody = endpoint.body
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        }
-
-        // Send request + Decode response
-        let (data, response) = try await session.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse,
-                (200...299).contains(httpResponse.statusCode) else {
-            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-            let serverMessage = try? JSONDecoder().decode(APIErrorResponse.self, from: data).message
-            throw APIError.badResponse(statusCode: statusCode, message: serverMessage, data: data)
-        }
-
-        return try JSONDecoder().decode(Response.self, from: data)
-    }
-
-    //old
-    func send<Response: Decodable>(_ endpoint: Endpoint, statusErrors: [Int: Error]) async throws -> Response {
         do {
-            return try await send(endpoint)
-        } catch APIError.badResponse(let statusCode, let message, let data) {
-            throw statusErrors[statusCode] ?? APIError.badResponse(statusCode: statusCode, message: message, data: data)
-        }
-    }
+            // Build URL
+            guard var components = URLComponents(
+                url: environment.baseURL, resolvingAgainstBaseURL: false
+            ) else { throw APIError.invalidURL }
 
-    func send<Response: Decodable, Failure: StatusMappedError>(_ endpoint: Endpoint, statusErrors: [Failure]) async throws -> Response {
-        do {
-            return try await send(endpoint)
+            components.path += endpoint.path.hasPrefix("/") ? endpoint.path : "/" + endpoint.path
+            if !endpoint.queryItems.isEmpty { components.queryItems = endpoint.queryItems }
+            guard let url = components.url else { throw APIError.invalidURL }
+
+            // Build request
+            var request = URLRequest(url: url)
+            request.httpMethod = endpoint.method.rawValue
+            request.setValue("true", forHTTPHeaderField: "ngrok-skip-browser-warning")
+
+            for (key, value) in endpoint.headers {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+
+            if endpoint.body != nil  {
+                request.httpBody = endpoint.body
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            }
+
+            // Send request + Decode response
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                    (200...299).contains(httpResponse.statusCode) else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                let serverMessage = try? JSONDecoder().decode(APIErrorResponse.self, from: data).message
+                throw APIError.badResponse(statusCode: statusCode, message: serverMessage, data: data)
+            }
+
+            return try JSONDecoder().decode(Response.self, from: data)
         } catch APIError.badResponse(let statusCode, let message, let data) {
-            throw statusErrors.first { $0.statusCode == statusCode } ?? APIError.badResponse(statusCode: statusCode, message: message, data: data)
+            throw APIError.badResponse(statusCode: statusCode, message: message, data: data)
         }
     }
 }

--- a/ios/SparkApp/SparkApp/Core/Habits/AddHabitView.swift
+++ b/ios/SparkApp/SparkApp/Core/Habits/AddHabitView.swift
@@ -1,0 +1,98 @@
+//
+//  AddHabitView.swift
+//  SparkApp
+//
+//  Created by Dmitro Kryzhanovsky on 08.07.2026.
+//
+
+import SwiftUI
+
+struct AddHabitView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(HabitManager.self) private var habitManager
+    @Environment(UsersManager.self) private var userManager
+
+    /// Called after a habit is successfully created, so the caller can reload.
+    let onCreated: () -> Void
+
+    @State private var name: String = ""
+    @State private var frequency: Frequency = .daily
+    @State private var isSaving: Bool = false
+    @State private var errorMessage: String?
+
+    enum Frequency: String, CaseIterable, Identifiable {
+        case daily, weekly, monthly
+        var id: String { rawValue }
+        var title: String { rawValue.capitalized }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Habit") {
+                    TextField("Name", text: $name)
+
+                    Picker("Frequency", selection: $frequency) {
+                        ForEach(Frequency.allCases) { frequency in
+                            Text(frequency.title).tag(frequency)
+                        }
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(AppColors.P2.primary)
+                            .font(.callout)
+                    }
+                }
+            }
+            .navigationTitle("New Habit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save") { save() }
+                        .disabled(!canSave || isSaving)
+                }
+            }
+        }
+    }
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private func save() {
+        guard let userId = userManager.currentUser?.id else {
+            errorMessage = "No signed-in user."
+            return
+        }
+
+        Task {
+            isSaving = true
+            defer { isSaving = false }
+            do {
+                errorMessage = nil
+                _ = try await habitManager.createHabit(
+                    name: name.trimmingCharacters(in: .whitespaces),
+                    frequency: frequency.rawValue,
+                    userId: userId
+                )
+                onCreated()
+                dismiss()
+            } catch let error as APIError {
+                errorMessage = error.errorDescription
+            } catch {
+                errorMessage = "Something went wrong. Please try again."
+            }
+        }
+    }
+}
+
+#Preview {
+    AddHabitView(onCreated: {})
+        .previewEnvironment()
+}

--- a/ios/SparkApp/SparkApp/Core/Habits/HabitsView.swift
+++ b/ios/SparkApp/SparkApp/Core/Habits/HabitsView.swift
@@ -11,10 +11,13 @@ struct HabitsView: View {
     
     @Environment(HealthManager.self) private var healthManager
     @Environment(HabitManager.self) private var habitManager
-    
+    @Environment(UsersManager.self) private var userManager
+    @Environment(LogManager.self) private var logManager
+
     @State private var health: ServerHealthDataModel = .goodMock
     @State private var habits: [HabitDataModel] = []
     @State private var isLoading: Bool = false
+    @State private var showAddHabit: Bool = false
     
     var body: some View {
         NavigationStack {
@@ -41,10 +44,16 @@ struct HabitsView: View {
             .navigationTitle("Habits")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
+                    addHabitButton
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     serverHealthButton
                 }
             }
             .devMenuToolbar()
+            .sheet(isPresented: $showAddHabit) {
+                addHabitSheet
+            }
             .task {
                 await checkServerHealth()
                 await loadHabits()
@@ -54,19 +63,39 @@ struct HabitsView: View {
     
     private func loadHabits() async {
         do {
-            habits = try await habitManager.getHabitsForUser(userId: "")
+            guard let userId = userManager.currentUser?.id else {
+                logManager.trackEvent(
+                    eventName: "HabitsView_LoadHabits_NoUser",
+                    type: .warning
+                )
+                return
+            }
+
+            habits = try await habitManager.getHabitsForUser(userId: userId)
         } catch {
-            print("Error loading habits: \(error)")
+            logManager.trackEvent(
+                eventName: "HabitsView_LoadHabits_Fail",
+                parameters: ["error": error.localizedDescription],
+                type: .severe
+            )
         }
     }
-    
+
     private func checkServerHealth() async {
         do {
             health = try await healthManager.getServerHealth()
-            print("Server status is: \(health.status.rawValue)")
+            logManager.trackEvent(
+                eventName: "HabitsView_ServerHealth",
+                parameters: ["status": health.status.rawValue],
+                type: .info
+            )
         } catch {
             health = ServerHealthDataModel(status: .bad)
-            print("Error checking server status: \(error)")
+            logManager.trackEvent(
+                eventName: "HabitsView_ServerHealth_Fail",
+                parameters: ["error": error.localizedDescription],
+                type: .severe
+            )
         }
     }
     
@@ -84,7 +113,7 @@ struct HabitsView: View {
         List {
             ForEach(habits, id: \.self ) { habit in
                 HStack {
-                    Text(habit.name ?? "")
+                    Text(habit.name)
                         .foregroundColor(AppColors.P2.textPrimary)
                     Spacer()
                 }
@@ -122,6 +151,20 @@ struct HabitsView: View {
             Label("Health", systemImage: "checkmark.icloud.fill")
         }
         .tint(health.status.color)
+    }
+
+    private var addHabitButton: some View {
+        Button {
+            showAddHabit = true
+        } label: {
+            Label("Add Habit", systemImage: "plus")
+        }
+    }
+
+    private var addHabitSheet: some View {
+        AddHabitView {
+            Task { await loadHabits() }
+        }
     }
 }
 

--- a/ios/SparkApp/SparkApp/Services/Habit/HabitManager.swift
+++ b/ios/SparkApp/SparkApp/Services/Habit/HabitManager.swift
@@ -10,14 +10,82 @@ import SwiftUI
 @MainActor
 @Observable
 class HabitManager {
-    
+
     var service: HabitService
-    
-    init(service: HabitService) {
+    private let logManager: LogManager?
+
+    init(service: HabitService, logManager: LogManager? = nil) {
         self.service = service
+        self.logManager = logManager
     }
-    
+
     func getHabitsForUser(userId: String) async throws -> [HabitDataModel] {
-        try await service.getHabitsForUser(userId: userId)
+        logManager?.trackEvent(event: Event.getHabitsStart(userId: userId))
+        do {
+            let habits = try await service.getHabitsForUser(userId: userId)
+            logManager?.trackEvent(event: Event.getHabitsSuccess(habits: habits))
+            return habits
+        } catch {
+            logManager?.trackEvent(event: Event.getHabitsFail(error: error))
+            throw error
+        }
+    }
+
+    func createHabit(name: String, frequency: String, userId: String) async throws -> HabitDataModel {
+        logManager?.trackEvent(event: Event.createHabitStart)
+        do {
+            let habit = try await service.createHabit(name: name, frequency: frequency, userId: userId)
+            logManager?.trackEvent(event: Event.createHabitSuccess(habit: habit))
+            return habit
+        } catch {
+            logManager?.trackEvent(event: Event.createHabitFail(error: error))
+            throw error
+        }
+    }
+}
+
+extension HabitManager {
+    enum Event: LoggableEvent {
+        case getHabitsStart(userId: String)
+        case getHabitsSuccess(habits: [HabitDataModel])
+        case getHabitsFail(error: Error)
+        case createHabitStart
+        case createHabitSuccess(habit: HabitDataModel)
+        case createHabitFail(error: Error)
+
+        var eventName: String {
+            switch self {
+            case .getHabitsStart:     "HabitManager_GetHabits_Start"
+            case .getHabitsSuccess:   "HabitManager_GetHabits_Success"
+            case .getHabitsFail:      "HabitManager_GetHabits_Fail"
+            case .createHabitStart:   "HabitManager_CreateHabit_Start"
+            case .createHabitSuccess: "HabitManager_CreateHabit_Success"
+            case .createHabitFail:    "HabitManager_CreateHabit_Fail"
+            }
+        }
+
+        var parameters: [String: Any]? {
+            switch self {
+            case .getHabitsStart(let userId):
+                ["user_id": userId]
+            case .getHabitsSuccess(let habits):
+                ["habits_count": habits.count]
+            case .createHabitSuccess(let habit):
+                habit.eventParameters
+            case .getHabitsFail(let error), .createHabitFail(let error):
+                ["error": error.localizedDescription]
+            default:
+                nil
+            }
+        }
+
+        var type: LogType {
+            switch self {
+            case .getHabitsFail, .createHabitFail:
+                    .severe
+            default:
+                    .analytic
+            }
+        }
     }
 }

--- a/ios/SparkApp/SparkApp/Services/Habit/Models/HabitCreateRequestBody.swift
+++ b/ios/SparkApp/SparkApp/Services/Habit/Models/HabitCreateRequestBody.swift
@@ -1,0 +1,11 @@
+//
+//  HabitCreateRequestBody.swift
+//  SparkApp
+//
+//  Created by Dmitro Kryzhanovsky on 08.07.2026.
+//
+
+struct HabitCreateRequestBody: Encodable {
+    let name: String
+    let frequency: String
+}

--- a/ios/SparkApp/SparkApp/Services/Habit/Models/HabitDataModel.swift
+++ b/ios/SparkApp/SparkApp/Services/Habit/Models/HabitDataModel.swift
@@ -7,70 +7,54 @@
 
 import SwiftUI
 
-enum HabitDataType: String, CaseIterable, Hashable {
-    case boolean
-    case counter
-}
+struct HabitDataModel: Hashable, Codable {
+    let id: Int
+    let userId: Int
+    let name: String
+    let frequency: String
 
-struct HabitDataModel: Hashable {
-    let id: String
-    let userId: String?
-    let name: String?
-    let description: String?
-    let type: HabitDataType?
-    let createdAt: Date?
-    let updatedAt: Date?
-    
     init(
-        id: String,
-        userId: String? = nil,
-        name: String? = nil,
-        description: String? = nil,
-        type: HabitDataType? = nil,
-        createdAt: Date? = nil,
-        updatedAt: Date? = nil
+        id: Int,
+        userId: Int,
+        name: String,
+        frequency: String
     ) {
         self.id = id
         self.userId = userId
         self.name = name
-        self.description = description
-        self.type = type
-        self.createdAt = createdAt
-        self.updatedAt = updatedAt
+        self.frequency = frequency
     }
-    
+
+    var eventParameters: [String: Any] {
+        [
+            "habit_id": id,
+            "habit_user_id": userId,
+            "habit_name": name,
+            "habit_frequency": frequency
+        ]
+    }
+
     static var mock: HabitDataModel { mocks[0] }
     
     static var mocks: [HabitDataModel] {
         [
             HabitDataModel(
-                id: "habit_1",
-                userId: "user_1",
+                id: 1,
+                userId: 1,
                 name: "Drink Water",
-                description: "Drink 2 liters of water every day",
-                type: .boolean,
-                createdAt: Date().addingTimeInterval(-86400 * 3),
-                updatedAt: Date().addingTimeInterval(-86400)
+                frequency: "daily"
             ),
-            
             HabitDataModel(
-                id: "habit_2",
-                userId: "user_1",
+                id: 2,
+                userId: 1,
                 name: "Push-ups",
-                description: "Do 50 push-ups",
-                type: .counter,
-                createdAt: Date().addingTimeInterval(-86400 * 7),
-                updatedAt: Date().addingTimeInterval(-86400 * 2)
+                frequency: "daily"
             ),
-            
             HabitDataModel(
-                id: "habit_3",
-                userId: "user_1",
+                id: 3,
+                userId: 2,
                 name: "Read a Book",
-                description: "Read at least 20 pages",
-                type: .boolean,
-                createdAt: Date().addingTimeInterval(-86400 * 10),
-                updatedAt: nil
+                frequency: "weekly"
             )
         ]
     }

--- a/ios/SparkApp/SparkApp/Services/Habit/Services/HabitService.swift
+++ b/ios/SparkApp/SparkApp/Services/Habit/Services/HabitService.swift
@@ -8,5 +8,6 @@
 import SwiftUI
 
 protocol HabitService: Sendable {
+    func createHabit(name: String, frequency: String, userId: String) async throws -> HabitDataModel
     func getHabitsForUser(userId: String) async throws -> [HabitDataModel]
 }

--- a/ios/SparkApp/SparkApp/Services/Habit/Services/MockHabitService.swift
+++ b/ios/SparkApp/SparkApp/Services/Habit/Services/MockHabitService.swift
@@ -15,7 +15,12 @@ struct MockHabitService: HabitService, MockService {
         self.delay = delay
         self.showError = showError
     }
-    
+
+    func createHabit(name: String, frequency: String, userId: String) async throws -> HabitDataModel {
+        try await executionBehaviour()
+        return HabitDataModel.mock
+    }
+
     func getHabitsForUser(userId: String) async throws -> [HabitDataModel] {
         try await executionBehaviour()
         return habits

--- a/ios/SparkApp/SparkApp/Services/Habit/Services/SparkHabitService.swift
+++ b/ios/SparkApp/SparkApp/Services/Habit/Services/SparkHabitService.swift
@@ -5,8 +5,34 @@
 //  Created by Dmitro Kryzhanovsky on 24.01.2026.
 //
 
+import Foundation
+
 struct SparkHabitService: HabitService {
+    private let client = APIClient()
+    
+    func createHabit(name: String, frequency: String, userId: String) async throws -> HabitDataModel {
+        let header = ["X-USER-ID": userId]
+        let body = try JSONEncoder().encode(HabitCreateRequestBody(name: name, frequency: frequency))
+
+        let endpoint = Endpoint(
+            path: "habits",
+            method: .post,
+            headers: header,
+            body: body
+        )
+
+        return try await client.send(endpoint)
+    }
+    
     func getHabitsForUser(userId: String) async throws -> [HabitDataModel] {
-        return []
+        let header = ["X-USER-ID": userId]
+
+        let endpoint = Endpoint(
+            path: "habits",
+            method: .get,
+            headers: header
+        )
+
+        return try await client.send(endpoint)
     }
 }

--- a/ios/SparkApp/SparkApp/Services/Health/HealthManager.swift
+++ b/ios/SparkApp/SparkApp/Services/Health/HealthManager.swift
@@ -12,12 +12,56 @@ import Foundation
 @Observable
 class HealthManager {
     var service: HealthService
+    private let logManager: LogManager?
 
-    init(service: HealthService) {
+    init(service: HealthService, logManager: LogManager? = nil) {
         self.service = service
+        self.logManager = logManager
     }
-    
+
     func getServerHealth() async throws -> ServerHealthDataModel {
-        try await service.getServerHealth()
+        logManager?.trackEvent(event: Event.getServerHealthStart)
+        do {
+            let health = try await service.getServerHealth()
+            logManager?.trackEvent(event: Event.getServerHealthSuccess(health: health))
+            return health
+        } catch {
+            logManager?.trackEvent(event: Event.getServerHealthFail(error: error))
+            throw error
+        }
+    }
+}
+
+extension HealthManager {
+    enum Event: LoggableEvent {
+        case getServerHealthStart
+        case getServerHealthSuccess(health: ServerHealthDataModel)
+        case getServerHealthFail(error: Error)
+
+        var eventName: String {
+            switch self {
+            case .getServerHealthStart:   "HealthManager_GetServerHealth_Start"
+            case .getServerHealthSuccess: "HealthManager_GetServerHealth_Success"
+            case .getServerHealthFail:    "HealthManager_GetServerHealth_Fail"
+            }
+        }
+
+        var parameters: [String: Any]? {
+            switch self {
+            case .getServerHealthSuccess(let health):
+                health.eventParameters
+            case .getServerHealthFail(let error):
+                ["error": error.localizedDescription]
+            default:
+                nil
+            }
+        }
+
+        var type: LogType {
+            switch self {
+            case .getServerHealthFail: .severe
+            default:                   .analytic
+            }
+        }
     }
 }

--- a/ios/SparkApp/SparkApp/Services/Health/Models/ServerHealthDataModel.swift
+++ b/ios/SparkApp/SparkApp/Services/Health/Models/ServerHealthDataModel.swift
@@ -33,6 +33,12 @@ enum ServerHealth: String, Codable {
 struct ServerHealthDataModel: Codable {
     let status: ServerHealth
 
+    var eventParameters: [String: Any] {
+        [
+            "server_status": status.rawValue
+        ]
+    }
+
     static var goodMock: Self {
         ServerHealthDataModel(status: .good)
     }

--- a/ios/SparkApp/SparkApp/Services/Users/Services/SparkUserService.swift
+++ b/ios/SparkApp/SparkApp/Services/Users/Services/SparkUserService.swift
@@ -7,28 +7,6 @@
 
 import Foundation
 
-protocol StatusMappedError: Error {
-    var statusCode: Int { get }
-}
-
-enum UserServiceError: StatusMappedError {
-    case unauthorized
-    case unknown
-    case conflict
-    case badRequest
-    case internalServerError
-
-    var statusCode: Int {
-        switch self {
-        case .internalServerError:           500
-        case .conflict:                      409
-        case .badRequest:                    400
-        case .unauthorized:                  401
-        case .unknown:                       -1   // never matches a real status
-        }
-    }
-}
-
 struct SparkUserService: UserService {
     private let client = APIClient()
 
@@ -41,8 +19,7 @@ struct SparkUserService: UserService {
             body: body
         )
 
-        return try await client.send(endpoint, statusErrors: [UserServiceError.conflict,
-                                                              UserServiceError.badRequest])
+        return try await client.send(endpoint)
     }
 
     func login(email: String, password: String) async throws -> UserDataModel {
@@ -54,8 +31,7 @@ struct SparkUserService: UserService {
             body: body
         )
 
-        return try await client.send(endpoint, statusErrors: [UserServiceError.unauthorized,
-                                                              UserServiceError.badRequest])
+        return try await client.send(endpoint)
     }
 
     func getUser(userId: String) async throws -> UserDataModel {
@@ -67,7 +43,6 @@ struct SparkUserService: UserService {
             headers: header
         )
 
-        return try await client.send(endpoint, statusErrors: [UserServiceError.internalServerError,
-                                                              UserServiceError.badRequest])
+        return try await client.send(endpoint)
     }
 }

--- a/ios/SparkApp/SparkApp/SparkAppApp.swift
+++ b/ios/SparkApp/SparkApp/SparkAppApp.swift
@@ -71,19 +71,19 @@ struct AppDependencies {
         switch config {
         case .mock:
             logManager    = LogManager(services: [ConsoleService(printParameters: false)])
-            healthManager = HealthManager(service: MockHealthService())
+            healthManager = HealthManager(service: MockHealthService(), logManager: logManager)
             userManager   = UsersManager(service: MockUserService(), logManager: logManager)
-            habitManager  = HabitManager(service: MockHabitService())
+            habitManager  = HabitManager(service: MockHabitService(), logManager: logManager)
         case .dev:
             logManager    = LogManager(services: [ConsoleService(printParameters: true)])
-            healthManager = HealthManager(service: SparkHealthService())
+            healthManager = HealthManager(service: SparkHealthService(), logManager: logManager)
             userManager   = UsersManager(service: SparkUserService(), logManager: logManager)
-            habitManager  = HabitManager(service: SparkHabitService())
+            habitManager  = HabitManager(service: SparkHabitService(), logManager: logManager)
         case .prod:
             logManager    = LogManager(services: [ConsoleService(printParameters: true)])
-            healthManager = HealthManager(service: SparkHealthService())
+            healthManager = HealthManager(service: SparkHealthService(), logManager: logManager)
             userManager   = UsersManager(service: SparkUserService(), logManager: logManager)
-            habitManager  = HabitManager(service: SparkHabitService())
+            habitManager  = HabitManager(service: SparkHabitService(), logManager: logManager)
         }
     }
 }


### PR DESCRIPTION
Add an AddHabitView for creating habits and connect HabitManager to a real SparkHabitService that POSTs to /habits and fetches the user's habits with the X-USER-ID header. Introduce HabitCreateRequestBody for the request payload.
Also simplify APIClient.send by folding error mapping into a single method and removing the unused statusErrors overloads.