### PR TITLE
Feature/backend/80 standardize api errors

### DIFF
--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/ApiErrorResponse.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/ApiErrorResponse.java
@@ -1,0 +1,14 @@
+package com.sparkapp.sparkapi.exception;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ApiErrorResponse(
+    Instant timestamp,
+    int status,
+    String error,
+    String message,
+    String path,
+    Map<String, String> fieldErrors
+) {
+}

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/EmailAlreadyRegisteredException.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/EmailAlreadyRegisteredException.java
@@ -1,0 +1,7 @@
+package com.sparkapp.sparkapi.exception;
+
+public class EmailAlreadyRegisteredException extends RuntimeException{
+    public EmailAlreadyRegisteredException() {
+        super("Email is already registered");
+    }
+}

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/GlobalExceptionHandler.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/GlobalExceptionHandler.java
@@ -1,0 +1,144 @@
+package com.sparkapp.sparkapi.exception;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationErrors(
+        MethodArgumentNotValidException exception,
+        HttpServletRequest request
+    ) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        
+        exception.getBindingResult()
+            .getFieldErrors()
+            .forEach(fieldError ->
+                fieldErrors.putIfAbsent(
+                    fieldError.getField(),
+                    fieldError.getDefaultMessage()    
+                )
+            );
+        
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        
+        ApiErrorResponse response = new ApiErrorResponse(
+            Instant.now(),
+            status.value(),
+            status.getReasonPhrase(),
+            "Validation failed",
+            request.getRequestURI(),
+            fieldErrors
+        );
+        
+        return ResponseEntity
+            .status(status)
+            .body(response);
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidCredentialsException(
+        InvalidCredentialsException exception,
+        HttpServletRequest request
+    ) {
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+
+        ApiErrorResponse response = new ApiErrorResponse(
+            Instant.now(),
+            status.value(),
+            status.getReasonPhrase(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            Map.of()
+        );
+        
+        return ResponseEntity
+            .status(status)
+            .body(response);
+    }
+
+        @ExceptionHandler(EmailAlreadyRegisteredException.class)
+    public ResponseEntity<ApiErrorResponse> handleEmailAlreadyRegisteredException(
+        EmailAlreadyRegisteredException exception,
+        HttpServletRequest request
+    ) {
+        HttpStatus status = HttpStatus.CONFLICT;
+
+        ApiErrorResponse response = new ApiErrorResponse(
+            Instant.now(),
+            status.value(),
+            status.getReasonPhrase(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            Map.of(
+                "email",
+                exception.getMessage()
+            )
+        );
+        
+        return ResponseEntity
+            .status(status)
+            .body(response);
+    }
+
+        @ExceptionHandler(PasswordDoNotMatchException.class)
+    public ResponseEntity<ApiErrorResponse> handlePasswordDoNotMatchException(
+        PasswordDoNotMatchException exception,
+        HttpServletRequest request
+    ) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        ApiErrorResponse response = new ApiErrorResponse(
+            Instant.now(),
+            status.value(),
+            status.getReasonPhrase(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            Map.of(
+                "passwordConfirmation",
+                exception.getMessage()
+            )
+        );
+        
+        return ResponseEntity
+            .status(status)
+            .body(response);
+    }
+
+        @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleUserNotFoundException(
+        UserNotFoundException exception,
+        HttpServletRequest request
+    ) {
+        HttpStatus status = HttpStatus.NOT_FOUND;
+
+        ApiErrorResponse response = new ApiErrorResponse(
+            Instant.now(),
+            status.value(),
+            status.getReasonPhrase(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            Map.of()
+        );
+        
+        return ResponseEntity
+            .status(status)
+            .body(response);
+    }
+
+
+}

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/InvalidCredentialsException.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package com.sparkapp.sparkapi.exception;
+
+public class InvalidCredentialsException extends RuntimeException{
+    public InvalidCredentialsException() {
+        super("Invalid email or password");
+    }
+}

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/PasswordDoNotMatchException.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/PasswordDoNotMatchException.java
@@ -1,0 +1,7 @@
+package com.sparkapp.sparkapi.exception;
+
+public class PasswordDoNotMatchException extends RuntimeException{
+    public PasswordDoNotMatchException() {
+        super("Passwords do not match");
+    }
+}

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/UserNotFoundException.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sparkapp.sparkapi.exception;
+
+public class UserNotFoundException extends RuntimeException{
+    public UserNotFoundException() {
+        super("User not found");
+    }
+}

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/service/AuthService.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/service/AuthService.java
@@ -2,13 +2,14 @@ package com.sparkapp.sparkapi.service;
 
 import java.util.Optional;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 import com.sparkapp.sparkapi.dto.LoginUserRequest;
 import com.sparkapp.sparkapi.dto.RegisterUserRequest;
 import com.sparkapp.sparkapi.dto.UserResponse;
+import com.sparkapp.sparkapi.exception.EmailAlreadyRegisteredException;
+import com.sparkapp.sparkapi.exception.InvalidCredentialsException;
+import com.sparkapp.sparkapi.exception.PasswordDoNotMatchException;
 import com.sparkapp.sparkapi.repository.UserRepository;
 import com.sparkapp.sparkapi.model.User;
 
@@ -25,15 +26,12 @@ public class AuthService {
 
     public UserResponse registerUser(RegisterUserRequest request) {
         if (!request.password().equals(request.passwordConfirmation())) {
-            throw new ResponseStatusException(
-                HttpStatus.BAD_REQUEST,
-                "Passwords do not match"
-            );
+            throw new PasswordDoNotMatchException();
         }
 
         Optional<User> userOptional = userRepository.findByEmail(request.email());
         if (!userOptional.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Email is already registered");
+            throw new EmailAlreadyRegisteredException();
         }
 
         User user = new User();
@@ -53,14 +51,14 @@ public class AuthService {
         Optional<User> userOptional = userRepository.findByEmail(request.email());
 
         if (userOptional.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid email or password");
+            throw new InvalidCredentialsException();
         }
 
         User user = userOptional.get();
         String passwordHash = fakeHashService.hashPassword(request.password());
 
         if (!user.getPasswordHash().equals(passwordHash)) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid email or password");
+            throw new InvalidCredentialsException();
         }
 
         return new UserResponse(

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/service/UserService.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/service/UserService.java
@@ -1,8 +1,11 @@
 package com.sparkapp.sparkapi.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import com.sparkapp.sparkapi.dto.UserResponse;
+import com.sparkapp.sparkapi.exception.UserNotFoundException;
 import com.sparkapp.sparkapi.model.User;
 import com.sparkapp.sparkapi.repository.UserRepository;
 
@@ -19,8 +22,13 @@ public class UserService {
 
     public UserResponse getCurrentUser(String userIdHeader) {
         Long currentUserId = fakeAuthService.getCurrentUserId(userIdHeader);
-        User user = userRepository.findById(currentUserId)
-                .orElseThrow();
+
+        Optional<User> userOptional = userRepository.findById(currentUserId);
+
+        if (userOptional.isEmpty()) {
+            throw new UserNotFoundException();
+        }
+        User user = userOptional.get();
         return new UserResponse(user.getId().toString(), user.getEmail());
 
     }

--- a/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/dto/LoginUserRequestTest.java
+++ b/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/dto/LoginUserRequestTest.java
@@ -29,4 +29,34 @@ public class LoginUserRequestTest {
 
         assertTrue(violations.isEmpty());
     }
+
+    @Test
+    void blankEmailProducesRequiredViolation() {
+        var request = new LoginUserRequest(
+            " ",
+            "password"
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("email")
+            && violation.getMessage().equals("Email is required")
+        ));
+    }
+
+    @Test
+    void blankPasswordProducesRequiredViolation() {
+        var request = new LoginUserRequest(
+            "test@example.com",
+            " "
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("password")
+            && violation.getMessage().equals("Password is required")
+        ));
+    }
 }

--- a/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/dto/RegisterUserRequestTest.java
+++ b/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/dto/RegisterUserRequestTest.java
@@ -30,4 +30,98 @@ public class RegisterUserRequestTest {
 
         assertTrue(violations.isEmpty());
     }
+
+    @Test
+    void blankEmailProducesRequiredViolation() {
+        var request = new RegisterUserRequest(
+            " ",
+            "password",
+            "password"
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("email")
+            && violation.getMessage().equals("Email is required")
+        ));
+    }
+
+    @Test
+    void malformedEmailProducesValidEmailViolation() {
+        var request = new RegisterUserRequest(
+            "not-an-email",
+            "password",
+            "password"
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("email")
+            && violation.getMessage().equals("Email must be valid")
+        ));
+    }
+
+    @Test
+    void blankPasswordProducesRequiredViolation() {
+        var request = new RegisterUserRequest(
+            "test@example.com",
+            " ",
+            "password"
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("password")
+            && violation.getMessage().equals("Password is required")
+        ));
+    }
+
+    @Test
+    void shortPasswordProducesMinimumLengthViolation() {
+        var request = new RegisterUserRequest(
+            "test@example.com",
+            "1234567",
+            "1234567"
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("password")
+            && violation.getMessage().equals("Password must be at least 8 characters")
+        ));
+    }
+
+    @Test
+    void exactlyEightCharacterPasswordHasNoViolations() {
+        var request = new RegisterUserRequest(
+            "test@example.com",
+            "12345678",
+            "12345678"
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    void blankPasswordConfirmationProducesRequiredViolation() {
+        var request = new RegisterUserRequest(
+            "test@example.com",
+            "password",
+            " "
+        );
+
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("passwordConfirmation")
+            && violation.getMessage().equals("Password confirmation is required")
+        ));
+    }
+
 }

--- a/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/service/AuthServiceTest.java
+++ b/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/service/AuthServiceTest.java
@@ -1,0 +1,118 @@
+package com.sparkapp.sparkapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sparkapp.sparkapi.dto.LoginUserRequest;
+import com.sparkapp.sparkapi.dto.RegisterUserRequest;
+import com.sparkapp.sparkapi.exception.EmailAlreadyRegisteredException;
+import com.sparkapp.sparkapi.exception.InvalidCredentialsException;
+import com.sparkapp.sparkapi.exception.PasswordDoNotMatchException;
+import com.sparkapp.sparkapi.model.User;
+import com.sparkapp.sparkapi.repository.UserRepository;
+
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FakeHashService fakeHashService;
+
+    @Mock
+    private FakeAuthService fakeAuthService;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        authService = new AuthService(fakeHashService, userRepository,  fakeAuthService);
+    }
+
+    @Test
+    void registerUserThrowsWhenPasswordsDoNotMatch() {
+        var request = new RegisterUserRequest(
+            "test@example.com",
+            "password123",
+            "different-password"
+        );
+
+
+
+        assertThrows(
+            PasswordDoNotMatchException.class,
+            () -> authService.registerUser(request)
+        );
+
+        verifyNoInteractions(userRepository, fakeHashService);
+    }
+
+    @Test
+    void registerUserThrowsWhenEmailAlreadyRegistered() {
+        var request = new RegisterUserRequest(
+            "test@example.com",
+            "password123",
+            "password123"
+        );
+
+        when(userRepository.findByEmail("test@example.com"))
+            .thenReturn(Optional.of(new User()));
+
+        assertThrows(
+            EmailAlreadyRegisteredException.class,
+            () -> authService.registerUser(request)
+        );
+
+        verify(userRepository).findByEmail("test@example.com");
+        verifyNoInteractions(fakeHashService);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void registerUserHashesPasswordSavesUserAndReturnsResponse() {
+        var request = new RegisterUserRequest(
+            "test@example.com",
+            "password123",
+            "password123"
+        );
+
+        when(userRepository.findByEmail("test@example.com"))
+            .thenReturn(Optional.empty());
+        when(fakeHashService.hashPassword("password123"))
+            .thenReturn("hashed-password");
+
+        when(fakeAuthService.getCurrentUserToken(1L))
+            .thenReturn("1");
+
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            user.setId(1L);
+            return user;
+        });
+
+        var response = authService.registerUser(request);
+
+        assertEquals("1", response.userId());
+        assertEquals("test@example.com", response.email());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+
+        User savedUser = userCaptor.getValue();
+        assertEquals("test@example.com", savedUser.getEmail());
+        assertEquals("hashed-password", savedUser.getPasswordHash());
+
+        verify(fakeHashService).hashPassword("password123");
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,34 @@ http://localhost:8081
 
 The port is currently configured in `backend/sparkapi/src/main/resources/application.properties`.
 
+## Error response format
+
+Handled API errors use this JSON envelope:
+
+```json
+{
+  "timestamp": "2026-07-12T10:15:30.123Z",
+  "status": 400,
+  "error": "Bad Request",
+  "message": "Validation failed",
+  "path": "/auth/register",
+  "fieldErrors": {
+    "email": "Email must be valid"
+  }
+}
+```
+
+Error response fields:
+
+- `timestamp` (`string`): UTC time at which the error response was created, in ISO-8601 format.
+- `status` (`number`): HTTP status code.
+- `error` (`string`): HTTP status reason phrase.
+- `message` (`string`): Summary of the error.
+- `path` (`string`): Request path that produced the error.
+- `fieldErrors` (`object`): Field name to validation-message mapping. This is empty when the error is not tied to a request field.
+
+For request-validation errors, `message` is `"Validation failed"` and `fieldErrors` contains the first error for each invalid field. For example, mismatched registration passwords return `400 Bad Request` with `fieldErrors.passwordConfirmation` set to `"Passwords do not match"`.
+
 ## Endpoints
 
 ### `GET /health`
@@ -85,6 +113,8 @@ Error responses:
 - `400 Bad Request`: A required field is blank, the email is invalid, the password is shorter than 8 characters, or the passwords do not match.
 - `409 Conflict`: The email address is already registered.
 
+For a password mismatch, the error is associated with the `passwordConfirmation` field. For a duplicate email, it is associated with the `email` field.
+
 
 ### `POST /auth/login`
 
@@ -128,6 +158,8 @@ Error responses:
 - `400 Bad Request`: Email or password is blank.
 - `401 Unauthorized`: The email is unknown or the password is incorrect.
 
+For invalid credentials, `message` is `"Invalid email or password"` and `fieldErrors` is empty.
+
 
 ### `GET /users/me`
 
@@ -162,6 +194,10 @@ Response fields:
 
 - `userId` (`string`): Current user ID from the fake-auth header.
 - `email` (`string`): Current user email.
+
+Error responses:
+
+- `404 Not Found`: No user exists for the current fake-auth user ID. The response message is `"User not found"` and `fieldErrors` is empty.
 
 
 ### `POST /habits`


### PR DESCRIPTION
## Summary

Standardizes backend API error responses with a shared `ApiErrorResponse` format.

- Replaces service-level `ResponseStatusException` usage with domain-specific exceptions.
- Adds global handling for validation, invalid credentials, duplicate email, password mismatch, and missing user errors.
- Adds DTO validation coverage and `AuthService` registration tests.
- Documents the shared error JSON format and endpoint-specific error cases.

## Linked issue

Closes #80

## Branch name

feature/backend/80-standardize-api-errors

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [x] Documentation
- [ ] CI / build
- [ ] Dependency update
- [ ] Repo maintenance
- [ ] Spike / research

## Area

- [x] Backend
- [ ] iOS
- [x] API
- [ ] Database
- [x] Auth
- [ ] CI
- [ ] Infrastructure
- [x] Documentation
- [ ] Repo

## Testing

- Reviewed the diff and ran `git diff --check`.
- Attempted `mvnw.cmd test`, but the Maven wrapper could not start because of a PowerShell invocation error.
- System Maven (`mvn`) is not installed in the environment.

## Notes / screenshots

Handled API errors now consistently return `timestamp`, `status`, `error`, `message`, `path`, and `fieldErrors`.

`GlobalExceptionHandler.java` has non-functional trailing whitespace reported by `git diff --check`; this should be cleaned up before the PR is marked ready for review.

## Final checklist

- [x] Branch name follows `<type>/<area>/<optional-issue-number>-<description>`
- [x] Branch area matches the issue area/template where possible
- [x] PR is linked to an issue, unless this is a tiny maintenance PR
- [ ] Code builds locally, or reason is explained
- [ ] Tests pass locally, or reason is explained
- [ ] No unrelated formatting changes
- [x] No secrets, `.env` files, generated files, or IDE junk committed