### PR TITLE
feat(ios): implement update habit into AddHabitView

### DIFF
--- a/ios/SparkApp/SparkApp/Core/AddHabit/AddHabitView.swift
+++ b/ios/SparkApp/SparkApp/Core/AddHabit/AddHabitView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AddHabitView: View {
     @Environment(\.dismiss) private var dismiss
     @State var viewModel: AddHabitViewModel
+    @FocusState private var isNameFocused: Bool
 
     /// Called after a habit is successfully created, so the caller can reload.
     let onCreated: () -> Void
@@ -19,6 +20,7 @@ struct AddHabitView: View {
             Form {
                 Section("Habit") {
                     TextField("Name", text: $viewModel.name)
+                        .focused($isNameFocused)
 
                     Picker("Frequency", selection: $viewModel.frequency) {
                         ForEach(HabitFrequency.allCases) { frequency in
@@ -35,7 +37,9 @@ struct AddHabitView: View {
                     }
                 }
             }
-            .navigationTitle("New Habit")
+            .scrollContentBackground(.hidden)
+            .background(AppColors.P2.background)
+            .navigationTitle(viewModel.isEditing ? "Edit Habit" : "New Habit")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -51,6 +55,11 @@ struct AddHabitView: View {
                     .disabled(!viewModel.canSave || viewModel.isSaving)
                 }
             }
+            .toolbarBackground(AppColors.P2.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+        }
+        .onAppear {
+            isNameFocused = true
         }
     }
 }

--- a/ios/SparkApp/SparkApp/Core/AddHabit/AddHabitViewModel.swift
+++ b/ios/SparkApp/SparkApp/Core/AddHabit/AddHabitViewModel.swift
@@ -13,20 +13,30 @@ class AddHabitViewModel {
     private let habitManager: HabitManager
     private let userManager: UserManager
     private let logManager: LogManager
-    
+    private let existingHabit: HabitDataModel?
+
     var name: String = ""
     var frequency: HabitFrequency = .daily
     private(set) var isSaving: Bool = false
     private(set) var errorMessage: String?
 
+    var isEditing: Bool {
+        existingHabit != nil
+    }
+
     var canSave: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
-    init(container: DependencyContainer) {
+    init(container: DependencyContainer, habit: HabitDataModel? = nil) {
         self.habitManager = container.resolve(HabitManager.self)!
         self.userManager = container.resolve(UserManager.self)!
         self.logManager = container.resolve(LogManager.self)!
+        self.existingHabit = habit
+        if let habit {
+            self.name = habit.name
+            self.frequency = HabitFrequency(rawValue: habit.frequency) ?? .daily
+        }
     }
 
     func save(onSuccess: @escaping () -> Void) {
@@ -34,7 +44,7 @@ class AddHabitViewModel {
             errorMessage = "No signed-in user."
             return
         }
-        
+
         let name = name.trimmingCharacters(in: .whitespacesAndNewlines)
 
         Task {
@@ -42,11 +52,20 @@ class AddHabitViewModel {
             defer { isSaving = false }
             do {
                 errorMessage = nil
-                _ = try await habitManager.createHabit(
-                    name: name,
-                    frequency: frequency.rawValue,
-                    userId: userId
-                )
+                if let existingHabit {
+                    _ = try await habitManager.updateHabit(
+                        id: existingHabit.id,
+                        userId: userId,
+                        name: name,
+                        frequency: frequency.rawValue
+                    )
+                } else {
+                    _ = try await habitManager.createHabit(
+                        name: name,
+                        frequency: frequency.rawValue,
+                        userId: userId
+                    )
+                }
                 onSuccess()
             } catch {
                 errorMessage = error.localizedDescription

--- a/ios/SparkApp/SparkApp/Core/Habits/HabitsListView.swift
+++ b/ios/SparkApp/SparkApp/Core/Habits/HabitsListView.swift
@@ -12,6 +12,7 @@ struct HabitsListView: View {
     @Environment(DependencyContainer.self) private var container
     @State var viewModel: HabitsListViewModel
     @State private var showAddHabit: Bool = false
+    @State private var habitToEdit: HabitDataModel?
 
     var body: some View {
         NavigationStack {
@@ -46,7 +47,12 @@ struct HabitsListView: View {
             }
             .devMenuToolbar()
             .sheet(isPresented: $showAddHabit) {
-                addHabitSheet
+                addHabitSheet(habit: nil)
+                    .habitFormPresentation()
+            }
+            .sheet(item: $habitToEdit) { habit in
+                addHabitSheet(habit: habit)
+                    .habitFormPresentation()
             }
             .task {
                 await viewModel.checkServerHealth()
@@ -76,6 +82,10 @@ struct HabitsListView: View {
                 .listRowBackground(
                     AppColors.P2.secondaryBackground
                 )
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    habitToEdit = habit
+                }
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                     Button(role: .destructive) {
                         Task {
@@ -126,10 +136,19 @@ struct HabitsListView: View {
         }
     }
 
-    private var addHabitSheet: some View {
-        AddHabitView(viewModel: AddHabitViewModel(container: container)) {
+    private func addHabitSheet(habit: HabitDataModel?) -> some View {
+        AddHabitView(viewModel: AddHabitViewModel(container: container, habit: habit)) {
             Task { await viewModel.loadHabits() }
         }
+    }
+}
+
+private extension View {
+    func habitFormPresentation() -> some View {
+        self
+            .presentationDetents([.height(260)])
+            .presentationBackground(AppColors.P2.background)
+            .presentationDragIndicator(.visible)
     }
 }
 

--- a/ios/SparkApp/SparkApp/Services/Habit/Models/HabitDataModel.swift
+++ b/ios/SparkApp/SparkApp/Services/Habit/Models/HabitDataModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct HabitDataModel: Hashable, Codable {
+struct HabitDataModel: Hashable, Codable, Identifiable {
     let id: Int
     let userId: Int
     var name: String


### PR DESCRIPTION
## Summary
Adds tap-to-edit support for habits in `HabitsListView`, reusing `AddHabitView`/`AddHabitViewModel` in an edit mode instead of a separate screen.

## Linked issue
Closes #98

## Branch name
feature/update-habit

## Type of change
- [x] Feature

## Area
- [x] iOS

## Testing
Manual: tapped a habit row, verified it opens pre-filled, edited name/frequency, saved, confirmed list refreshes with updated values and title reads "Edit Habit".

## Notes / screenshots

## Final checklist
- [ ] Branch name follows `<type>/<area>/<optional-issue-number>-<description>`
- [x] Branch area matches the issue area/template where possible
- [x] PR is linked to an issue, unless this is a tiny maintenance PR
- [x] Code builds locally, or reason is explained
- [x] Tests pass locally, or reason is explained
- [x] No unrelated formatting changes
- [x] No secrets, `.env` files, generated files, or IDE junk committed