### PR TITLE
refactor(ios): base implementation to support iOS 18 UI

### DIFF
--- a/ios/SparkApp/SparkApp/Core/AddHabit/AddHabitView.swift
+++ b/ios/SparkApp/SparkApp/Core/AddHabit/AddHabitView.swift
@@ -43,7 +43,10 @@ struct AddHabitView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .tint(.primary)
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Save") {
@@ -52,6 +55,7 @@ struct AddHabitView: View {
                             dismiss()
                         }
                     }
+                    .tint(.primary)
                     .disabled(!viewModel.canSave || viewModel.isSaving)
                 }
             }

--- a/ios/SparkApp/SparkApp/Core/Habits/HabitsListView.swift
+++ b/ios/SparkApp/SparkApp/Core/Habits/HabitsListView.swift
@@ -123,7 +123,8 @@ struct HabitsListView: View {
         Button {
             Task { await viewModel.checkServerHealth() }
         } label: {
-            Label("Health", systemImage: "checkmark.icloud.fill")
+            Image(systemName: "checkmark.icloud.fill")
+                .font(.title2)
         }
         .tint(viewModel.health.status.color)
     }
@@ -132,8 +133,11 @@ struct HabitsListView: View {
         Button {
             showAddHabit = true
         } label: {
-            Label("Add Habit", systemImage: "plus")
+            Image(systemName: "plus")
+                .font(.title2)
+                .foregroundStyle(.primary)
         }
+        .tint(.primary)
     }
 
     private func addHabitSheet(habit: HabitDataModel?) -> some View {

--- a/ios/SparkApp/SparkApp/Extensions/DevMenuToolbar.swift
+++ b/ios/SparkApp/SparkApp/Extensions/DevMenuToolbar.swift
@@ -27,8 +27,11 @@ private struct DevMenuToolbar: ViewModifier {
                     Button {
                         showDevMenu = true
                     } label: {
-                        Label("Dev Menu", systemImage: "hammer.fill")
+                        Image(systemName: "hammer.fill")
+                            .font(.title3)
+                            .foregroundStyle(.primary)
                     }
+                    .tint(.primary)
                 }
             }
             .sheet(isPresented: $showDevMenu) {


### PR DESCRIPTION
## Summary
Updates toolbar buttons in `HabitsListView`, `AddHabitView`, and `DevMenuToolbar` to icon-only styling with consistent `.primary` tint, as a base pass toward iOS 18 design conventions.

## Linked issue
Closes #100

## Branch name
refactor/18-ios-design

## Type of change
- [x] Refactor

## Area
- [x] iOS

## Testing
Manual: verified toolbar buttons render icon-only with correct tint on Habits list, Add/Edit Habit sheet, and Dev Menu; confirmed no behavior change to tap actions.

## Notes / screenshots

## Final checklist
- [ ] Branch name follows `<type>/<area>/<optional-issue-number>-<description>`
- [x] Branch area matches the issue area/template where possible
- [x] PR is linked to an issue, unless this is a tiny maintenance PR
- [x] Code builds locally, or reason is explained
- [x] Tests pass locally, or reason is explained
- [x] No unrelated formatting changes
- [x] No secrets, `.env` files, generated files, or IDE junk committed