### PR TITLE
feat(users): complete self-service user CRUD

### DIFF
--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/controller/UserController.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/controller/UserController.java
@@ -1,14 +1,20 @@
 package com.sparkapp.sparkapi.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sparkapp.sparkapi.dto.UpdateUserRequest;
 import com.sparkapp.sparkapi.dto.UserResponse;
 import com.sparkapp.sparkapi.service.UserService;
 
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.GetMapping;
-
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/users")
@@ -16,16 +22,25 @@ public class UserController {
 
     private final UserService userService;
 
-    public UserController(UserService userService){
+    public UserController(UserService userService) {
         this.userService = userService;
     }
-
-
 
     @GetMapping("/me")
     public UserResponse getCurrentUser(@RequestHeader("X-USER-ID") String userIdHeader) {
         return userService.getCurrentUser(userIdHeader);
+    }
 
+    @PatchMapping("/me")
+    public UserResponse updateCurrentUser(@RequestHeader("X-USER-ID") String userIdHeader,
+            @Valid @RequestBody UpdateUserRequest updateUserRequest) {
+        return userService.updateCurrentUser(userIdHeader, updateUserRequest);
+    }
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteCurrentUser(@RequestHeader("X-USER-ID") String userIdHeader) {
+        userService.deleteCurrentUser(userIdHeader);
     }
 
 }

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/dto/UpdateUserRequest.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/dto/UpdateUserRequest.java
@@ -1,0 +1,10 @@
+package com.sparkapp.sparkapi.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserRequest(
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    String email
+) {}

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/repository/HabitRepository.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/repository/HabitRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparkapp.sparkapi.model.Habit;
 
-public interface HabitRepository extends JpaRepository<Habit, Long>{
+public interface HabitRepository extends JpaRepository<Habit, Long> {
     List<Habit> findByUserId(Long userId);
     Optional<Habit> findByIdAndUserId(Long id, Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/service/UserService.java
+++ b/backend/sparkapi/src/main/java/com/sparkapp/sparkapi/service/UserService.java
@@ -1,35 +1,75 @@
 package com.sparkapp.sparkapi.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.sparkapp.sparkapi.dto.UpdateUserRequest;
 import com.sparkapp.sparkapi.dto.UserResponse;
+import com.sparkapp.sparkapi.exception.EmailAlreadyRegisteredException;
 import com.sparkapp.sparkapi.exception.UserNotFoundException;
 import com.sparkapp.sparkapi.model.User;
+import com.sparkapp.sparkapi.repository.HabitRepository;
 import com.sparkapp.sparkapi.repository.UserRepository;
 
 @Service
 public class UserService {
 
+    private final HabitRepository habitRepository;
     private final UserRepository userRepository;
     private final FakeAuthService fakeAuthService;
 
-    public UserService(UserRepository userRepository, FakeAuthService fakeAuthService) {
+    public UserService(UserRepository userRepository,
+            FakeAuthService fakeAuthService, HabitRepository habitRepository) {
         this.userRepository = userRepository;
         this.fakeAuthService = fakeAuthService;
+        this.habitRepository = habitRepository;
     }
 
     public UserResponse getCurrentUser(String userIdHeader) {
-        Long currentUserId = fakeAuthService.getCurrentUserId(userIdHeader);
+        Long currentUserId = fakeAuthService
+                .getCurrentUserId(userIdHeader);
 
-        Optional<User> userOptional = userRepository.findById(currentUserId);
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(UserNotFoundException::new);
 
-        if (userOptional.isEmpty()) {
-            throw new UserNotFoundException();
-        }
-        User user = userOptional.get();
         return new UserResponse(user.getId(), user.getEmail());
 
+    }
+
+    public UserResponse updateCurrentUser(
+            String userIdHeader,
+            UpdateUserRequest request) {
+        Long currentUserId = fakeAuthService
+                .getCurrentUserId(userIdHeader);
+
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!request.email().equals(user.getEmail())) {
+            if (userRepository.findByEmail(request.email()).isPresent()) {
+                throw new EmailAlreadyRegisteredException();
+            }
+
+            user.setEmail(request.email());
+        }
+
+        User updatedUser = userRepository.save(user);
+        return prepareUserResponse(updatedUser);
+    }
+
+    @Transactional
+    public void deleteCurrentUser(String userIdHeader) {
+        Long currentUserId = fakeAuthService
+                .getCurrentUserId(userIdHeader);
+
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        habitRepository.deleteAllByUserId(currentUserId);
+        userRepository.delete(user);
+    }
+
+    private UserResponse prepareUserResponse(User user) {
+        return new UserResponse(user.getId(), user.getEmail());
     }
 }

--- a/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/controller/UserControllerTest.java
+++ b/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/controller/UserControllerTest.java
@@ -1,17 +1,27 @@
 package com.sparkapp.sparkapi.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.sparkapp.sparkapi.dto.UpdateUserRequest;
 import com.sparkapp.sparkapi.dto.UserResponse;
+import com.sparkapp.sparkapi.exception.EmailAlreadyRegisteredException;
 import com.sparkapp.sparkapi.exception.UserNotFoundException;
 import com.sparkapp.sparkapi.service.UserService;
 
@@ -40,6 +50,112 @@ class UserControllerTest {
         when(userService.getCurrentUser("1")).thenThrow(new UserNotFoundException());
 
         mockMvc.perform(get("/users/me").header("X-USER-ID", "1"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("User not found"));
+    }
+
+    @Test
+    void updateCurrentUserReturnsUpdatedUser() throws Exception {
+        when(userService.updateCurrentUser(eq("1"), any(UpdateUserRequest.class)))
+            .thenReturn(new UserResponse(1L, "updated@example.com"));
+
+        mockMvc.perform(patch("/users/me")
+                .header("X-USER-ID", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "email": "updated@example.com"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.email").value("updated@example.com"));
+
+        verify(userService).updateCurrentUser(eq("1"), any(UpdateUserRequest.class));
+    }
+
+    @Test
+    void updateCurrentUserReturnsBadRequestWhenEmailIsInvalid() throws Exception {
+        mockMvc.perform(patch("/users/me")
+                .header("X-USER-ID", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "email": "not-an-email"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Validation failed"))
+            .andExpect(jsonPath("$.fieldErrors.email").value("Email must be valid"));
+
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    void updateCurrentUserReturnsBadRequestWhenEmailIsBlank() throws Exception {
+        mockMvc.perform(patch("/users/me")
+                .header("X-USER-ID", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "email": ""
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Validation failed"))
+            .andExpect(jsonPath("$.fieldErrors.email").value("Email is required"));
+
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    void updateCurrentUserReturnsConflictWhenEmailIsRegistered() throws Exception {
+        when(userService.updateCurrentUser(eq("1"), any(UpdateUserRequest.class)))
+            .thenThrow(new EmailAlreadyRegisteredException());
+
+        mockMvc.perform(patch("/users/me")
+                .header("X-USER-ID", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "email": "taken@example.com"
+                    }
+                    """))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("Email is already registered"))
+            .andExpect(jsonPath("$.fieldErrors.email").value("Email is already registered"));
+    }
+
+    @Test
+    void updateCurrentUserReturnsNotFoundWhenUserDoesNotExist() throws Exception {
+        when(userService.updateCurrentUser(eq("1"), any(UpdateUserRequest.class)))
+            .thenThrow(new UserNotFoundException());
+
+        mockMvc.perform(patch("/users/me")
+                .header("X-USER-ID", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "email": "updated@example.com"
+                    }
+                    """))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("User not found"));
+    }
+
+    @Test
+    void deleteCurrentUserReturnsNoContent() throws Exception {
+        mockMvc.perform(delete("/users/me").header("X-USER-ID", "1"))
+            .andExpect(status().isNoContent());
+
+        verify(userService).deleteCurrentUser("1");
+    }
+
+    @Test
+    void deleteCurrentUserReturnsNotFoundWhenUserDoesNotExist() throws Exception {
+        doThrow(new UserNotFoundException()).when(userService).deleteCurrentUser("1");
+
+        mockMvc.perform(delete("/users/me").header("X-USER-ID", "1"))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message").value("User not found"));
     }

--- a/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/service/UserServiceTest.java
+++ b/backend/sparkapi/src/test/java/com/sparkapp/sparkapi/service/UserServiceTest.java
@@ -2,7 +2,12 @@ package com.sparkapp.sparkapi.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -10,11 +15,15 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sparkapp.sparkapi.dto.UpdateUserRequest;
+import com.sparkapp.sparkapi.exception.EmailAlreadyRegisteredException;
 import com.sparkapp.sparkapi.exception.UserNotFoundException;
 import com.sparkapp.sparkapi.model.User;
+import com.sparkapp.sparkapi.repository.HabitRepository;
 import com.sparkapp.sparkapi.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,11 +35,14 @@ class UserServiceTest {
     @Mock
     private FakeAuthService fakeAuthService;
 
+    @Mock
+    private HabitRepository habitRepository;
+
     private UserService userService;
 
     @BeforeEach
     void setUp() {
-        userService = new UserService(userRepository, fakeAuthService);
+        userService = new UserService(userRepository, fakeAuthService, habitRepository);
     }
 
     @Test
@@ -56,5 +68,109 @@ class UserServiceTest {
 
         assertThrows(UserNotFoundException.class, () -> userService.getCurrentUser("4"));
         verify(userRepository).findById(4L);
+    }
+
+    @Test
+    void updateCurrentUserUpdatesEmailAndReturnsMappedResponse() {
+        User user = user(4L, "old@example.com");
+        when(fakeAuthService.getCurrentUserId("4")).thenReturn(4L);
+        when(userRepository.findById(4L)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+        when(userRepository.save(user)).thenReturn(user);
+
+        var response = userService.updateCurrentUser(
+            "4",
+            new UpdateUserRequest("new@example.com")
+        );
+
+        assertEquals(4L, response.id());
+        assertEquals("new@example.com", response.email());
+        assertEquals("new@example.com", user.getEmail());
+        verify(userRepository).findByEmail("new@example.com");
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void updateCurrentUserAllowsKeepingExistingEmail() {
+        User user = user(4L, "same@example.com");
+        when(fakeAuthService.getCurrentUserId("4")).thenReturn(4L);
+        when(userRepository.findById(4L)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+
+        var response = userService.updateCurrentUser(
+            "4",
+            new UpdateUserRequest("same@example.com")
+        );
+
+        assertEquals("same@example.com", response.email());
+        verify(userRepository, never()).findByEmail(anyString());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void updateCurrentUserThrowsWhenEmailBelongsToAnotherUser() {
+        User user = user(4L, "old@example.com");
+        User otherUser = user(5L, "taken@example.com");
+        when(fakeAuthService.getCurrentUserId("4")).thenReturn(4L);
+        when(userRepository.findById(4L)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail("taken@example.com")).thenReturn(Optional.of(otherUser));
+
+        assertThrows(
+            EmailAlreadyRegisteredException.class,
+            () -> userService.updateCurrentUser(
+                "4",
+                new UpdateUserRequest("taken@example.com")
+            )
+        );
+
+        assertEquals("old@example.com", user.getEmail());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void updateCurrentUserThrowsWhenUserDoesNotExist() {
+        when(fakeAuthService.getCurrentUserId("4")).thenReturn(4L);
+        when(userRepository.findById(4L)).thenReturn(Optional.empty());
+
+        assertThrows(
+            UserNotFoundException.class,
+            () -> userService.updateCurrentUser(
+                "4",
+                new UpdateUserRequest("new@example.com")
+            )
+        );
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void deleteCurrentUserDeletesOwnedHabitsBeforeUser() {
+        User user = user(4L, "user@example.com");
+        when(fakeAuthService.getCurrentUserId("4")).thenReturn(4L);
+        when(userRepository.findById(4L)).thenReturn(Optional.of(user));
+
+        userService.deleteCurrentUser("4");
+
+        InOrder deletionOrder = inOrder(habitRepository, userRepository);
+        deletionOrder.verify(habitRepository).deleteAllByUserId(4L);
+        deletionOrder.verify(userRepository).delete(user);
+    }
+
+    @Test
+    void deleteCurrentUserThrowsWithoutDeletingWhenUserDoesNotExist() {
+        when(fakeAuthService.getCurrentUserId("4")).thenReturn(4L);
+        when(userRepository.findById(4L)).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> userService.deleteCurrentUser("4"));
+
+        verifyNoInteractions(habitRepository);
+        verify(userRepository, never()).delete(any(User.class));
+    }
+
+    private User user(Long id, String email) {
+        User user = new User();
+        user.setId(id);
+        user.setEmail(email);
+        return user;
     }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -200,6 +200,73 @@ Error responses:
 - `404 Not Found`: No user exists for the current fake-auth user ID. The response message is `"User not found"` and `fieldErrors` is empty.
 
 
+### `PATCH /users/me`
+
+Purpose:
+Updates the email address of the current user identified by the temporary fake-auth `X-USER-ID` header.
+
+Request:
+
+- Content-Type: `application/json`
+- Required header: `X-USER-ID`
+
+Example request:
+
+```json
+{
+  "email": "updated@email.com"
+}
+```
+
+Request fields:
+
+- `email` (`string`, required): Nonblank, valid email address that is not registered to another user.
+
+Response:
+
+- Status: `200 OK`
+- Content-Type: `application/json`
+
+Example response:
+
+```json
+{
+  "id": 1,
+  "email": "updated@email.com"
+}
+```
+
+Response fields:
+
+- `id` (`number`): Current user ID.
+- `email` (`string`): Updated user email.
+
+Error responses:
+
+- `400 Bad Request`: The email is blank or invalid.
+- `404 Not Found`: No user exists for the current fake-auth user ID.
+- `409 Conflict`: The email is already registered to another user.
+
+
+### `DELETE /users/me`
+
+Purpose:
+Deletes the current user and all habits owned by that user.
+
+Request:
+
+- Required header: `X-USER-ID`
+
+Response:
+
+- Status: `204 No Content`
+- Body: none
+
+Error responses:
+
+- `404 Not Found`: No user exists for the current fake-auth user ID. No habits or user record are deleted.
+
+
 ### `POST /habits`
 
 Purpose:
@@ -429,7 +496,7 @@ Response fields:
 
 ## Notes
 
-- This API is in an early stage and currently exposes health checks, registration, login, current-user lookup, and habit CRUD operations.
+- This API is in an early stage and currently exposes health checks, registration, login, current-user CRUD operations, and habit CRUD operations.
 - User and habit records are persisted through JPA.
 - Authentication is currently fake: `X-USER-ID` is parsed as the current numeric user ID.
 - Spring Security's `PasswordEncoder` encodes passwords, and only encoded passwords are persisted.

--- a/docs/requests.http
+++ b/docs/requests.http
@@ -179,6 +179,46 @@ GET {{baseUrl}}/users/me
 GET {{baseUrl}}/users/me
 X-USER-ID: not-a-number
 
+### Update current user
+# Expected: 200 OK with roman.updated@example.com.
+PATCH {{baseUrl}}/users/me
+Content-Type: application/json
+X-USER-ID: {{userId}}
+
+{
+  "email": "roman.updated@example.com"
+}
+
+### Update current user with invalid email
+# Expected: 400 Bad Request with fieldErrors.email set to "Email must be valid".
+PATCH {{baseUrl}}/users/me
+Content-Type: application/json
+X-USER-ID: {{userId}}
+
+{
+  "email": "not-an-email"
+}
+
+### Update current user with blank email
+# Expected: 400 Bad Request with fieldErrors.email set to "Email is required".
+PATCH {{baseUrl}}/users/me
+Content-Type: application/json
+X-USER-ID: {{userId}}
+
+{
+  "email": ""
+}
+
+### Update current user with another user's email
+# Expected: 409 Conflict because second@example.com belongs to user 2.
+PATCH {{baseUrl}}/users/me
+Content-Type: application/json
+X-USER-ID: {{userId}}
+
+{
+  "email": "second@example.com"
+}
+
 ### Create habit for first user
 # Expected: 201 Created
 POST {{baseUrl}}/habits
@@ -313,4 +353,19 @@ X-USER-ID: {{userId}}
 ### Get deleted habit
 # Expected: 404 Not Found after the delete request above.
 GET {{baseUrl}}/habits/{{habitId}}
+X-USER-ID: {{userId}}
+
+### Delete current user
+# Expected: 204 No Content. Also deletes the user's remaining habits.
+DELETE {{baseUrl}}/users/me
+X-USER-ID: {{userId}}
+
+### Get deleted current user
+# Expected: 404 Not Found after deleting the user above.
+GET {{baseUrl}}/users/me
+X-USER-ID: {{userId}}
+
+### List deleted user's habits
+# Expected: 200 OK with an empty list, confirming associated habits were deleted.
+GET {{baseUrl}}/habits
 X-USER-ID: {{userId}}


### PR DESCRIPTION
## Summary

- Add `PATCH /users/me` for updating the current user’s email.
- Validate email updates and reject emails registered to another account.
- Add `DELETE /users/me` with transactional deletion of the user and their habits.
- Add focused service and controller tests.
- Update the API documentation and HTTP request examples.

## Linked issue

Closes #89

## Branch name

`feature/backend/89-self-service-user-crud`

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [x] Documentation
- [ ] CI / build
- [ ] Dependency update
- [ ] Repo maintenance
- [ ] Spike / research

## Area

- [x] Backend
- [ ] iOS
- [x] API
- [ ] Database
- [ ] Auth
- [ ] CI
- [ ] Infrastructure
- [x] Documentation
- [ ] Repo

## Testing

Ran the complete backend Maven test suite:

`.\mvnw.cmd test`

Verified:

- Email updates return the updated user.
- Blank and invalid email addresses return `400 Bad Request`.
- Emails registered to another account return `409 Conflict`.
- Missing current users return `404 Not Found`.
- Keeping the current email remains valid.
- Account deletion removes the user’s habits before deleting the user.
- Successful account deletion returns `204 No Content`.
- All 62 tests pass with no failures or errors.

## Notes / screenshots

Account deletion uses explicit habit cleanup through `HabitRepository` within the same transaction as user deletion. Database-level cascading and migrations are not introduced by this change.

No screenshots are applicable to this backend-only change.

## Final checklist

- [x] Branch name follows `<type>/<area>/<optional-issue-number>-<description>`
- [x] Branch area matches the issue area/template where possible
- [x] PR is linked to an issue, unless this is a tiny maintenance PR
- [x] Code builds locally, or reason is explained
- [x] Tests pass locally, or reason is explained
- [x] No unrelated formatting changes
- [x] No secrets, `.env` files, generated files, or IDE junk committed